### PR TITLE
添加 auto_convert! 方法, 用于自动替换字符串里的符号

### DIFF
--- a/lib/auto-correct.rb
+++ b/lib/auto-correct.rb
@@ -10,22 +10,30 @@ class String
     self.gsub! /([a-zA-Z0-9+$’”\]\)@#!\/]|[\d[年月日]]{2,})((?![年月日号])\p{Han})/u do
       "#$1 #$2"
     end
-    
+
     # Fix () [] near the English and number
     self.gsub! /([a-zA-Z0-9]+)([\[\(‘“])/u do
       "#$1 #$2"
     end
-    
+
     self.gsub! /([\)\]’”])([a-zA-Z0-9]+)/u do
       "#$1 #$2"
     end
-    
+
     self
   end
-  
+
+  def auto_convert!(conversion = AutoCorrect::CONVERSION)
+    conversion.each do |key, value|
+      self.gsub!(key, value)
+    end
+
+    self
+  end
+
   def auto_correct!
     self.auto_space!
-    
+
     self.gsub! /([\d\p{Han}：:]|\s|^)([a-zA-Z\d\-\_\.]+)([\d\p{Han},，。；]|\s|$)/u do
       key = "#$2".downcase
       if AutoCorrect::DICTS.has_key?(key)
@@ -34,7 +42,7 @@ class String
         "#$1#$2#$3"
       end
     end
-    
+
     self
   end
 end

--- a/lib/auto-correct/dicts.rb
+++ b/lib/auto-correct/dicts.rb
@@ -69,7 +69,7 @@ module AutoCorrect
     "rubymotion"    => "RubyMotion",
     "irb"           => "IRB",
     "pry"           => "Pry",
-    
+
     # Python
 
     # Node.js
@@ -77,17 +77,17 @@ module AutoCorrect
     "npm"           => "NPM",
 
     # Go
-    
+
     # PHP
     "php"           => "PHP",
     "pear"          => "Pear",
-    
+
     # Cocoa
     "afnetworking"  => "AFNetworking",
     "reactivecocoa" => "ReactiveCocoa",
     "three20"       => "Three20",
-    
-    # Java 
+
+    # Java
 
     # Programming
     "ssh"           => "SSH",
@@ -121,7 +121,6 @@ module AutoCorrect
     "i18n"          => "I18N",
     "markdown"      => "Markdown",
 
-
     # Sites
     "amazon"        => "Amazon",
     "aws"           => "AWS",
@@ -138,7 +137,6 @@ module AutoCorrect
     "stackexchange" => "StackExchange",
     "twitter"       => "Twitter",
     "youtube"       => "YouTube",
-    
 
     # Databases
     "dynamodb"      => "DynamoDB",
@@ -152,7 +150,7 @@ module AutoCorrect
     "elasticsearch" => "Elasticsearch",
     "solr"          => "Solr",
     "sphinx"        => "Sphinx",
-    
+
     # System
     "window"        => "Windows",
     "linux"         => "Linux",
@@ -179,7 +177,7 @@ module AutoCorrect
     "imagemagick"   => "ImageMagick",
     "fluentd"       => "Fluentd",
     "ffmpeg"        => "FFMPEG",
-    
+
     # Tools
     "git"           => "Git",
     "svn"           => "SVN",
@@ -216,8 +214,6 @@ module AutoCorrect
     "iphone"        => "iPhone",
     "ipad"          => "iPad",
     "android"       => "Android",
-    "osx"           => "OS X",
-    "mac"           => "Mac",
     "imac"          => "iMac",
     "macbookpro"    => "MacBook Pro",
     "macbook"       => "MacBook",
@@ -228,6 +224,13 @@ module AutoCorrect
     "vpn"           => "VPN",
     "arm"           => "ARM",
     "cpu"           => "CPU",
-    
+
+  }
+
+  CONVERSION        = {
+    "【"            => "[",
+    "】"            => "]",
+    "（"            => "(",
+    "）"            => ")"
   }
 end

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -139,6 +139,18 @@ describe "AutoCorrect" do
     it { "明日大家都在这里".auto_space!.should == "明日大家都在这里" }
   end
 
+  describe ".auto_convert!" do
+    context "default conversion" do
+      it { "【北京】".auto_convert!.should == "[北京]" }
+      it { "（（北京））".auto_convert!.should == "((北京))" }
+    end
+
+    context "custom conversion" do
+      it { "[上海]".auto_convert!({ "[" => "【", "]" => "】" }).should == "【上海】" }
+      it { "(上海)".auto_convert!({ "(" => "（", ")" => "）" }).should == "（上海）" }
+    end
+  end
+
   describe ".auto_correct!" do
     context "between word" do
       it { "mOngodb".auto_correct!.should == "MongoDB" }
@@ -147,7 +159,7 @@ describe "AutoCorrect" do
       it { "的mongodb".auto_correct!.should == "的 MongoDB" }
       it { "mongodb的".auto_correct!.should == "MongoDB 的" }
     end
-    
+
     context "all words" do
       it "should word" do
         AutoCorrect::DICTS.map do |key, val|
@@ -164,7 +176,7 @@ describe "AutoCorrect" do
     context "with -" do
       it { "ruby-china社区".auto_correct!.should == "Ruby China 社区" }
     end
-    
+
     context "do not change domain / code" do
       it { "www.ruby-lang.org".auto_correct!.should == "www.ruby-lang.org" }
       it { "rails 4.1.0.rc1 rubber fails, foo.rails.root set to nil".auto_correct!.should == "Rails 4.1.0.rc1 rubber fails, foo.rails.root set to nil" }
@@ -180,7 +192,7 @@ describe "AutoCorrect" do
       it { "全新的ruby web框架：lotus".auto_correct!.should == "全新的 Ruby web 框架：Lotus" }
       it { "grape写纯 api，选择哪个oauth gem好呢？".auto_correct!.should == "Grape 写纯 API，选择哪个 OAuth gem 好呢？" }
     end
-    
+
     context 'with ActiveModel field_changed?' do
       it {
         u = User.new


### PR DESCRIPTION
默认替换字符串中的中文括号、中括号到英文，可带入参数自定义替换规则。

看到 ruby-china 最新的 commit 信息所以过来看了下 auto-space 的代码， 觉得自动替换标题里面的中文中括号和括号到英文的功能可以合并到 auto-correct 中， 并替换 auto-space gem 到 auto-correct gem， 这样会不会好一点？